### PR TITLE
Fixed timezone consistency in tests

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -142,7 +142,7 @@ class RegistryTestCase(UberjobTestCase):
     def test_fresh_time_advanced(self):
         p = uberjob.Plan()
         r = uberjob.Registry()
-        t0 = dt.datetime.now()
+        t0 = dt.datetime.utcnow()
         store_a = TestStore(7, modified_time=t0)
         a = r.source(p, store_a)
         store_c = TestStore()


### PR DESCRIPTION
**What**
Changed the test test_fresh_time_advanced in test_registry.py to use UTC time consistently by replacing dt.datetime.now() with dt.datetime.utcnow().
**Why**
The test was failing because it was mixing local time and UTC time when making timestamp comparisons:

1. _The test was creating timestamps using dt.datetime.now() (local time)_
2._But the TestStore.write method internally sets its modified_time using dt.datetime.utcnow()_
3 _This created an inconsistent comparison where timestamps were in different time zones_

![photo_2025-03-03_17-16-42](https://github.com/user-attachments/assets/bf09d5ab-dd9d-42be-9056-9e5fd2e6b5ca)


This change ensures all timestamps in the test are in UTC, allowing for reliable timestamp comparisons regardless of the environment timezone settings.